### PR TITLE
 Added basic twig file linting

### DIFF
--- a/bin/twiglint
+++ b/bin/twiglint
@@ -1,0 +1,15 @@
+#!/usr/bin/env php
+<?php
+
+declare( strict_types=1 );
+
+if ( file_exists( $a = __DIR__.'/../../../autoload.php' ) ) {
+	require_once $a;
+} else {
+	require_once __DIR__.'/../vendor/autoload.php';
+}
+
+$purifier = new WMDE\Fundraising\HtmlFilter\HtmlPurifier();
+
+echo 'Doing absolutely nothing with ' . $_SERVER['argv'][1] . PHP_EOL;
+exit( 0 );

--- a/bin/twiglint
+++ b/bin/twiglint
@@ -9,7 +9,4 @@ if ( file_exists( $a = __DIR__.'/../../../autoload.php' ) ) {
 	require_once __DIR__.'/../vendor/autoload.php';
 }
 
-$purifier = new WMDE\Fundraising\HtmlFilter\HtmlPurifier();
-
-echo 'Doing absolutely nothing with ' . $_SERVER['argv'][1] . PHP_EOL;
-exit( 0 );
+exit( ( new WMDE\Fundraising\HtmlFilter\TwigLinter() )->lint( $_SERVER['argv'][1] ?? null ) );

--- a/composer.json
+++ b/composer.json
@@ -35,5 +35,8 @@
         "phpcs": [
             "vendor/bin/phpcs src/ test/ --standard=phpcs.xml --extensions=php -sp"
         ]
-    }
+    },
+    "bin": [
+        "bin/twiglint"
+    ]
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,6 +2,7 @@
          backupStaticAttributes="false"
          cacheTokens="false"
          colors="true"
+         beStrictAboutTestsThatDoNotTestAnything="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="false"
          convertWarningsToExceptions="true"

--- a/src/TwigLinter.php
+++ b/src/TwigLinter.php
@@ -1,0 +1,64 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace WMDE\Fundraising\HtmlFilter;
+
+use WMDE\Fundraising\HtmlFilter\HtmlPurifier as FunHtmlPurifier;
+
+class TwigLinter {
+
+	private $exitWithError;
+
+	public function __construct( callable $exitWithError = null ) {
+		$this->exitWithError = $exitWithError ?? function( $handle, string $errorMessage ) {
+			fwrite( $handle, $errorMessage );
+			exit( 1 );
+		};
+	}
+
+	public function lint( ?string $fileName ): int {
+		if ( $fileName === null || trim( $fileName ) === '' ) {
+			$this->outputError( 'Required file name argument not provided' );
+			return 1;
+		}
+
+		echo "Validating $fileName... ";
+
+		$fileContent = @file_get_contents( $fileName );
+
+		if ( !is_string( $fileContent ) ) {
+			$this->outputError( 'Could not read file' );
+			return 1;
+		}
+
+		return $this->lintContent( $fileContent );
+	}
+
+	private function outputError( string $errorMessage ) {
+		call_user_func( $this->exitWithError, STDERR, 'ERROR: ' . $errorMessage . PHP_EOL );
+	}
+
+	private function lintContent( string $fileContent ): int {
+		$purifier = new FunHtmlPurifier();
+
+		$purifiedContent = $purifier->purify( $fileContent );
+
+		if ( $this->unifyHtml( $fileContent ) !== $this->unifyHtml( $purifiedContent ) ) {
+			$this->outputError(
+				'Impure HTML:' . PHP_EOL
+				. "\tOriginal: " .  $this->unifyHtml( $fileContent ) . PHP_EOL
+				. "\tPurified: " .  $this->unifyHtml( $purifiedContent ) . PHP_EOL
+			);
+			return 1;
+		}
+
+		echo 'OK' . PHP_EOL;
+		return 0;
+	}
+
+	private function unifyHtml( string $html ): string {
+		return preg_replace( '/(\s+|\/)/', '', $html );
+	}
+
+}

--- a/test/TwigLinterTest.php
+++ b/test/TwigLinterTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace WMDE\Fundraising\HtmlFilter\Test;
+
+use PHPUnit\Framework\TestCase;
+use WMDE\Fundraising\HtmlFilter\TwigLinter;
+
+class TwigLinterTest extends TestCase {
+
+	public function testGivenNullFileName_errorIsOutput() {
+		$linter = new TwigLinter( function( $handle, string $errorMessage ) {
+			$this->assertSame( 'ERROR: Required file name argument not provided' . PHP_EOL, $errorMessage );
+		} );
+
+		$linter->lint( null );
+	}
+
+	public function testGivenEmptyFileName_errorIsOutput() {
+		$linter = new TwigLinter( function( $handle, string $errorMessage ) {
+			$this->assertSame( 'ERROR: Required file name argument not provided' . PHP_EOL, $errorMessage );
+		} );
+
+		$linter->lint( '' );
+	}
+
+	public function testGivenNonExistingFileName_errorIsOutput() {
+		$errorWasOutput = false;
+
+		$linter = new TwigLinter( function( $handle, string $errorMessage ) use ( &$errorWasOutput ) {
+			$this->assertSame( 'ERROR: Could not read file' . PHP_EOL, $errorMessage );
+			$errorWasOutput = true;
+		} );
+
+		$this->expectOutputRegex( '/Validating/' );
+		$this->assertSame( 1, $linter->lint( '/tmp/pink-fluffy-unicorns-dancing-on-rainbows.kittens' ) );
+		$this->assertTrue( $errorWasOutput, 'Error should be output' );
+	}
+
+	public function testGivenNameOfFileWithValidHtml_noErrorsAreOutput() {
+		$linter = new TwigLinter( function( $handle, string $errorMessage ) {
+			$this->fail( 'No errors should be output, yet got: ' . $errorMessage );
+		} );
+
+		$this->expectOutputRegex( '/OK/' );
+		$this->assertSame( 0, $linter->lint( __DIR__ . '/data/ValidTwigFile.twig' ) );
+	}
+
+	public function testGivenNameOfFileWithInvalidHtml_errorIsOutput() {
+		$errorWasOutput = false;
+
+		$linter = new TwigLinter( function( $handle, string $errorMessage ) use ( &$errorWasOutput ) {
+			$this->assertContains( 'Impure HTML', $errorMessage );
+			$errorWasOutput = true;
+		} );
+
+		$this->expectOutputRegex( '/Validating/' );
+		$linter->lint( __DIR__ . '/data/InvalidTwigFile.twig' );
+		$this->assertTrue( $errorWasOutput, 'Error should be output' );
+	}
+
+}

--- a/test/data/InvalidTwigFile.twig
+++ b/test/data/InvalidTwigFile.twig
@@ -1,0 +1,11 @@
+<h1>my test <em>site</em></h1>
+<p>lorem</p>
+<ul>
+    <li>item <strong>1</strong></li>
+</ul>
+<script>alert('Pink Fluffy Unicorns Dancing On Rainbows');</script>
+
+<img src="/logo.png" alt="wikimedia" />
+some<br>
+thing<br/>
+new

--- a/test/data/ValidTwigFile.twig
+++ b/test/data/ValidTwigFile.twig
@@ -1,0 +1,10 @@
+<h1>my test <em>site</em></h1>
+<p>lorem</p>
+<ul>
+    <li>item <strong>1</strong></li>
+</ul>
+
+<img src="/logo.png" alt="wikimedia" />
+some<br>
+thing<br/>
+new


### PR DESCRIPTION
The twiglint script now checks if the HTML remains "unchanged"
when it is stuffed though the purifier. "unchanged" ignoring
whitespace and slashes (slahes cause purifier changes `<br>` into `<br/>`).

This CLI output stuff is making me feel so dirty. Perhaps should have
gone with the Console component :)

For https://phabricator.wikimedia.org/T162286